### PR TITLE
xlog y축 조정 단위 변경

### DIFF
--- a/src/components/Paper/XLog/XLog.js
+++ b/src/components/Paper/XLog/XLog.js
@@ -447,18 +447,19 @@ class XLog extends Component {
         this.redraw();
     };
 
-
     axisUp = (e) => {
-        common.setLocalSettingData(XLOG_ELAPSED, this.state.elapsed * 2);
+        const yValue = this.state.elapsed >= 3000 ? this.state.elapsed * 1.3 : this.state.elapsed * 1.7;
+        common.setLocalSettingData(XLOG_ELAPSED, yValue);
         this.setState({
-            elapsed: this.state.elapsed * 2
+            elapsed: yValue
         });
     };
 
     axisDown = () => {
-        common.setLocalSettingData(XLOG_ELAPSED, this.state.elapsed / 2);
+        const yValue = this.state.elapsed >= 3000 ? this.state.elapsed / 1.3 : this.state.elapsed / 1.7;
+        common.setLocalSettingData(XLOG_ELAPSED, yValue);
         this.setState({
-            elapsed: this.state.elapsed / 2
+            elapsed: yValue
         });
     };
 


### PR DESCRIPTION
XLog y축 조정 단위가 너무 커서 좀 더 작은 단위로 움직이도록 수정. 2x -> 숫자가 작은 경우 1.3x, 큰 경우 1.7x
issue #53 처리