### PR TITLE
Zipkin Span step support.

### DIFF
--- a/src/components/Paper/XLog/Profiler/SingleProfile/SingleProfile.js
+++ b/src/components/Paper/XLog/Profiler/SingleProfile/SingleProfile.js
@@ -263,6 +263,10 @@ const stepMeta = {
         name: "apicall2",
         getNavName: (step) => "CALL API"
     },
+    52: {
+        name: "spancall",
+        getNavName: (step) => "CALL SPAN"
+    },
     7: {
         name: "threadSubmit",
         getNavName: (step) => "CALL THREAD"

--- a/src/components/Paper/XLog/Profiler/SingleProfile/SingleProfile.js
+++ b/src/components/Paper/XLog/Profiler/SingleProfile/SingleProfile.js
@@ -2,6 +2,8 @@ import React, {Component} from 'react';
 import './SingleProfile.css';
 import HashedMessageStep from "./HashedMessageStep/HashedMessageStep";
 import MethodStep from "./MethodStep/MethodStep";
+import SpanStep from "./SpanStep/SpanStep";
+import SpanCallStep from "./SpanCallStep/SpanCallStep";
 import SqlStep from "./SqlStep/SqlStep";
 import MessageStep from "./MessageStep/MessageStep";
 import SocketStep from "./SocketStep/SocketStep";
@@ -434,6 +436,8 @@ class SingleProfile extends Component {
                                 {row.step.stepType === "2" && <SqlStep txLinkClick={this.txLinkClick} narrow={this.props.narrow} startTime={startTime} row={row}/>}
                                 {row.step.stepType === "8" && <Sql2Step txLinkClick={this.txLinkClick} narrow={this.props.narrow} startTime={startTime} row={row}/>}
                                 {row.step.stepType === "1" && <MethodStep txLinkClick={this.txLinkClick} narrow={this.props.narrow} startTime={startTime} row={row}/>}
+                                {row.step.stepType === "51" && <SpanStep txLinkClick={this.txLinkClick} narrow={this.props.narrow} startTime={startTime} row={row}/>}
+                                {row.step.stepType === "52" && <SpanCallStep txLinkClick={this.txLinkClick} narrow={this.props.narrow} startTime={startTime} row={row}/>}
                                 {row.step.stepType === "10" && <Method2Step txLinkClick={this.txLinkClick} narrow={this.props.narrow} startTime={startTime} row={row}/>}
                                 {row.step.stepType === "3" && <MessageStep txLinkClick={this.txLinkClick} narrow={this.props.narrow} startTime={startTime} row={row}/>}
                                 {row.step.stepType === "5" && <SocketStep txLinkClick={this.txLinkClick} narrow={this.props.narrow} startTime={startTime} row={row}/>}

--- a/src/components/Paper/XLog/Profiler/SingleProfile/SpanCallStep/SpanCallStep.css
+++ b/src/components/Paper/XLog/Profiler/SingleProfile/SpanCallStep/SpanCallStep.css
@@ -1,0 +1,28 @@
+.spancall-step .message-content {
+    padding: 9px 15px;
+    color: #1a237e;
+    font-weight: bold;
+    font-size: 11px;
+}
+
+.spancall-step .message-content.url:before {
+    content:"[CALL] ";
+}
+
+.spancall-step .message-content.tag:before {
+    content:"   -> ";
+}
+
+.narrow .spancall-step .message-content {
+    padding: 2px 15px;
+}
+
+.spancall-step .message-content.url {
+    background-color: #fff9c4;
+}
+
+.spancall-step .message-content.tag {
+    font-weight: normal;
+    color: #AAAAAA;
+}
+

--- a/src/components/Paper/XLog/Profiler/SingleProfile/SpanCallStep/SpanCallStep.js
+++ b/src/components/Paper/XLog/Profiler/SingleProfile/SpanCallStep/SpanCallStep.js
@@ -1,0 +1,64 @@
+import React, {Component} from 'react';
+import './SpanCallStep.css';
+import StepGeneral from "../StepGeneral/StepGeneral";
+import TxNavLink from "../TxNavLink/TxNavLink";
+import Error from "../Error/Error";
+/*
+    public int hash;
+    public int elapsed;
+    public int error;
+    public long timestamp;
+    public byte spanType;
+    public Endpoint localEndpoint;
+    public Endpoint remoteEndpoint;
+    public boolean debug;
+    public boolean shared;
+    public List<SpanAnnotation> annotations;
+    public Map<String, String> tags;
+
+    //call remote
+    public long txid;
+    public String address;
+    public byte async;
+
+    public static class SpanAnnotation {
+        long timestamp;
+        String value;
+    }
+    public static class Endpoint {
+        int hash;
+        String serviceName;
+        String ip;
+        int port;
+    }
+ */
+class SpanCallStep extends Component {
+    render() {
+        console.log(this.props.row);
+        const step = this.props.row.step;
+
+        let localEndpoint = step.localEndpoint.serviceName ? JSON.stringify(step.localEndpoint) : null;
+        let remoteEndpoint = step.remoteEndpoint.serviceName ? JSON.stringify(step.remoteEndpoint) : null;
+        let tags = (step.tags && Object.keys(step.tags).length > 0) ? JSON.stringify(step.tags) : null;
+        let annotations = (step.annotation && step.annotation.length > 0) ?JSON.stringify(step.annotations) : null;
+
+        return (
+            <div className="step spancall-step">
+                <StepGeneral startTime={this.props.startTime} row={this.props.row} elapsed={this.props.row.step.elapsed} type="SPANCALL"/>
+                <TxNavLink txLinkClick={this.props.txLinkClick} row={this.props.row}></TxNavLink>
+                {(isNaN(this.props.row.step.error) || Number(this.props.row.step.error) > 0) && <Error row={this.props.row}></Error>}
+                <div className="message-content url">{this.props.row.mainValue} {'[addr] ' + this.props.row.step.address}</div>
+                {(localEndpoint) &&
+                <div className="message-content tag">localEndPoint: {localEndpoint}</div>}
+                {(remoteEndpoint) &&
+                <div className="message-content tag">remoteEndPoint: {localEndpoint}</div>}
+                {(tags) &&
+                <div className="message-content tag">tags: {tags}</div>}
+                {(annotations) &&
+                <div className="message-content tag">annotations: {annotations}</div>}
+            </div>
+        )
+    }
+}
+
+export default SpanCallStep;

--- a/src/components/Paper/XLog/Profiler/SingleProfile/SpanStep/SpanStep.css
+++ b/src/components/Paper/XLog/Profiler/SingleProfile/SpanStep/SpanStep.css
@@ -1,0 +1,21 @@
+.span-step .message-content {
+    color: #5B59BA;
+    padding: 9px 5px;
+}
+
+.narrow .span-step .message-content {
+    padding: 2px 5px;
+}
+
+.span-step .message-content .gray {
+    color: #AAAAAA;
+}
+
+.span-step .message-content.tag:before {
+    content:"   -> ";
+}
+
+.span-step .message-content.tag {
+    font-weight: normal;
+    color: #AAAAAA;
+}

--- a/src/components/Paper/XLog/Profiler/SingleProfile/SpanStep/SpanStep.js
+++ b/src/components/Paper/XLog/Profiler/SingleProfile/SpanStep/SpanStep.js
@@ -1,0 +1,57 @@
+import React, {Component} from 'react';
+import './SpanStep.css';
+import StepGeneral from "../StepGeneral/StepGeneral";
+import TxNavLink from "../TxNavLink/TxNavLink";
+/*
+    public int hash;
+    public int elapsed;
+    public int error;
+    public long timestamp;
+    public byte spanType;
+    public Endpoint localEndpoint;
+    public Endpoint remoteEndpoint;
+    public boolean debug;
+    public boolean shared;
+    public List<SpanAnnotation> annotations;
+    public Map<String, String> tags;
+
+    public static class SpanAnnotation {
+        long timestamp;
+        String value;
+    }
+    public static class Endpoint {
+        int hash;
+        String serviceName;
+        String ip;
+        int port;
+    }
+ */
+class SpanStep extends Component {
+    render() {
+        console.log(this.props.row);
+        const step = this.props.row.step;
+
+        let localEndpoint = step.localEndpoint.serviceName ? JSON.stringify(step.localEndpoint) : null;
+        let remoteEndpoint = step.remoteEndpoint.serviceName ? JSON.stringify(step.remoteEndpoint) : null;
+        let tags = (step.tags && Object.keys(step.tags).length > 0) ? JSON.stringify(step.tags) : null;
+        let annotations = (step.annotation && step.annotation.length > 0) ?JSON.stringify(step.annotations) : null;
+
+        return (
+            <div className="step span-step">
+                <StepGeneral startTime={this.props.startTime} row={this.props.row} elapsed={this.props.row.step.elapsed} type="SPAN"/>
+                <TxNavLink txLinkClick={this.props.txLinkClick} row={this.props.row}></TxNavLink>
+                <div className="message-content">{this.props.row.mainValue}</div>
+                {(localEndpoint) &&
+                    <div className="message-content tag">localEndPoint: {localEndpoint}</div>}
+                {(remoteEndpoint) &&
+                    <div className="message-content tag">remoteEndPoint: {localEndpoint}</div>}
+                {(tags) &&
+                    <div className="message-content tag">tags: {tags}</div>}
+                {(annotations) &&
+                    <div className="message-content tag">annotations: {annotations}</div>}
+            </div>
+        )
+    }
+}
+
+export default SpanStep;


### PR DESCRIPTION
릴리즈 예정인 Scouter 2.5에서 지원하는 Zipkin support 호환성 작업.

SpanStep, SpanCallStep 추가.

* 의견
  * tag 클래스가 부여된 항목들이 현재 PR 처럼 아래에 나오는 것이 아니고
      * main value click(or mouse over)시 창이 떠서 보여지도록 고쳐주시면 좋을 것 같습니다.


* 아직 데모 환경에는 Zikpkin 기능 구성이 되지는 않았음. 
